### PR TITLE
Included reward chance roll

### DIFF
--- a/src/main/java/su/nightexpress/excellentjobs/grind/table/SourceTable.java
+++ b/src/main/java/su/nightexpress/excellentjobs/grind/table/SourceTable.java
@@ -80,7 +80,11 @@ public class SourceTable implements Writeable {
             return defValue == null ? reward : reward.add(defValue.roll());
         }
 
-        rewards.forEach(other -> reward.add(other.roll()));
+        rewards.forEach(other -> {
+            if (other.checkChance()) {
+                reward.add(other.roll());
+            }
+        });
 
         return reward;
     }
@@ -95,13 +99,20 @@ public class SourceTable implements Writeable {
             return defValue == null ? reward : reward.add(defValue.roll());
         }
 
-        return sourceReward.roll();
+        if (sourceReward.checkChance()) {
+            return sourceReward.roll();
+        }
+        return reward;
     }
 
     @NotNull
     public <O> GrindReward rollForEntity(@NotNull O entity, @NotNull GrindAdapterFamily<O> family) {
         GrindReward reward = new GrindReward();
-        this.getEntries(entity, family).forEach(other -> reward.add(other.roll()));
+        this.getEntries(entity, family).forEach(other -> {
+            if (other.checkChance()) {
+                reward.add(other.roll());
+            }
+        });
         return reward;
     }
 


### PR DESCRIPTION
Hi!
This PR fixes an issue where `SourceReward#chance` was never evaluated.
The reward roll methods always called `roll()` directly without checking `checkChance()`, causing rewards to be granted unconditionally.