### PR TITLE
fix(command): fix IllegalArgumentException in /jobs xp give/take commands

### DIFF
--- a/src/main/java/su/nightexpress/excellentjobs/level/command/LevelingCommands.java
+++ b/src/main/java/su/nightexpress/excellentjobs/level/command/LevelingCommands.java
@@ -82,7 +82,7 @@ public class LevelingCommands implements CommandProvider {
                         Arguments.playerName(ARG_PLAYER),
                         Arguments.argument(ARG_JOB, Job.class)
                             .localized(Lang.COMMAND_ARGUMENT_NAME_JOB.text()),
-                        Arguments.integer(ARG_AMOUNT, 1)
+                        Arguments.decimal(ARG_AMOUNT, 1D)
                             .localized(CoreLang.COMMAND_ARGUMENT_NAME_AMOUNT.text())
                             .suggestions((reader, context) -> Lists.newList("10", "20", "30", "40", "50"))
 
@@ -95,7 +95,7 @@ public class LevelingCommands implements CommandProvider {
                         Arguments.playerName(ARG_PLAYER),
                         Arguments.argument(ARG_JOB, Job.class)
                             .localized(Lang.COMMAND_ARGUMENT_NAME_JOB.text()),
-                        Arguments.integer(ARG_AMOUNT, 1)
+                        Arguments.decimal(ARG_AMOUNT, 1D)
                             .localized(CoreLang.COMMAND_ARGUMENT_NAME_AMOUNT.text())
                             .suggestions((reader, context) -> Lists.newList("10", "20", "30", "40", "50"))
 


### PR DESCRIPTION
This PR fixes a `IllegalArgumentException` thrown when executing the `/jobs xp give` and `/jobs xp take` commands.

### Cause
In [LevelingCommands.java](src/main/java/su/nightexpress/excellentjobs/level/command/LevelingCommands.java), the `amount` argument was defined using `Arguments.integer(...)`, but the command executors (`giveXP` and `takeXP`) were trying to retrieve the value using `arguments.getDouble("amount")`. This resulted in the following exception:
```
java.lang.IllegalArgumentException: Argument 'amount' is defined as Integer, not class java.lang.Double
```
Additionally, entering decimal values (e.g. `10.0`) was rejected by the command parser validation since it expected a strict integer.

### Solution
Updated the command arguments declaration in [LevelingCommands.java](src/main/java/su/nightexpress/excellentjobs/level/command/LevelingCommands.java) from `Arguments.integer(...)` to `Arguments.decimal(...)` to match the expected `Double` type in the executor logic.
